### PR TITLE
Shorten "Green Dragon Software Ltd" in Navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand page-scroll" href="#page-top">Green Dragon Software Ltd</a>
+                <a class="navbar-brand page-scroll" href="#page-top">Green Dragon</a>
             </div>
 
             <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
It's too long and doesn't look right in responsive mode.
